### PR TITLE
Added a gradle build

### DIFF
--- a/proxy/src/test/gradle/010-slf4j/build.gradle
+++ b/proxy/src/test/gradle/010-slf4j/build.gradle
@@ -1,0 +1,18 @@
+apply plugin: "java"
+apply plugin: "application"
+
+mainClassName = 'org.uli.logging.EchoServer'
+
+dependencies {
+    compile group: 'org.slf4j',     name: 'slf4j-api',     version: '1.7.5'
+    compile group: 'org.slf4j',     name: 'slf4j-log4j12', version: '1.7.5'
+    testCompile group: 'junit',     name: 'junit',         version: '4.11'
+}
+
+repositories {
+    mavenCentral()
+}
+
+clean.doLast {
+  project.delete 'logging.log', 'logging-junit.log'
+}

--- a/proxy/src/test/gradle/010-slf4j/gradle.properties
+++ b/proxy/src/test/gradle/010-slf4j/gradle.properties
@@ -1,0 +1,5 @@
+systemProp.http.proxyHost=localhost
+systemProp.http.proxyPort=8081
+systemProp.http.proxyUser=username
+systemProp.http.proxyPassword=password
+systemProp.http.nonProxyHosts=*.nonproxyrepos.com|localhost

--- a/proxy/src/test/gradle/010-slf4j/src/main/java/org/uli/logging/EchoServer.java
+++ b/proxy/src/test/gradle/010-slf4j/src/main/java/org/uli/logging/EchoServer.java
@@ -1,0 +1,23 @@
+package org.uli.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EchoServer {
+
+    final Logger logger = LoggerFactory.getLogger(EchoServer.class);
+
+    public String echo(String shoutOut) {
+        logger.debug("-> shoutOut={}", shoutOut);
+        String result = shoutOut;
+        logger.debug("<- result={}", result);
+        return result;
+    }
+
+    public static void main(String[] args) {
+        EchoServer echoServer = new EchoServer();
+        for (String shoutOut : args) {
+            System.out.println("'" + shoutOut + "' -> '" + echoServer.echo(shoutOut) + "'");
+        }
+    }
+}

--- a/proxy/src/test/gradle/010-slf4j/src/main/resources/log4j.xml
+++ b/proxy/src/test/gradle/010-slf4j/src/main/resources/log4j.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration>
+    <appender name="file" class="org.apache.log4j.FileAppender">
+        <param name="File" value="logging.log"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{yyyy-MM-dd} %d{ABSOLUTE} [%t] %5p %C:%L-%M() - %m%n" />
+        </layout>
+    </appender>
+
+    <root>
+        <priority value="trace"></priority>
+        <appender-ref ref="file"/>
+    </root>
+</log4j:configuration>

--- a/proxy/src/test/gradle/010-slf4j/src/test/java/org/uli/logging/EchoServerTest.java
+++ b/proxy/src/test/gradle/010-slf4j/src/test/java/org/uli/logging/EchoServerTest.java
@@ -1,0 +1,14 @@
+package org.uli.logging;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class EchoServerTest {
+
+    @Test
+    public void testEcho() {
+        EchoServer echoServer = new EchoServer();
+        String echo = echoServer.echo("UliWasHere!");
+        assertEquals("UliWasHere!", echo);
+    }
+}

--- a/proxy/src/test/gradle/010-slf4j/src/test/resources/log4j.xml
+++ b/proxy/src/test/gradle/010-slf4j/src/test/resources/log4j.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration>
+    <appender name="file" class="org.apache.log4j.FileAppender">
+        <param name="File" value="logging-junit.log"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{yyyy-MM-dd} %d{ABSOLUTE} [%t] %5p %C:%L-%M() - %m%n" />
+        </layout>
+    </appender>
+
+    <root>
+        <priority value="trace"></priority>
+        <appender-ref ref="file"/>
+    </root>
+</log4j:configuration>

--- a/proxy/src/test/gradle/run-gradle-tests.sh
+++ b/proxy/src/test/gradle/run-gradle-tests.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+#
+# Run some tests based on moxie proxy and gradle.
+# Make sure that:
+# - you're able to run moxie proxie, i.e. the required tcp ports aren't in use
+# - you don't run jetty at the moment - it will be killed by this script :(
+# - you have gradle available and you can run it via "gradle" (I'm using 1.8.-rc-1 at the moment)
+#
+# I've tested this script on Linux only.
+#
+
+D="$(dirname "$0")"
+D="$(cd "${D}"; pwd)"
+
+BN="$(basename "$0")"
+
+GRADLE_CACHE="${D}/gradle-user-home"
+MOXIE_PROXY="${D}/../../.."
+MOXIE_PROXY_CACHE="${MOXIE_PROXY}/moxie"
+MOXIE_PROXY_OUTPUT="${D}/moxie-proxie.output.txt"
+
+# clean the moxie proxy cache
+rm -rf "${MOXIE_PROXY_CACHE}"
+
+killJetty () {
+  ps -ao pid,command|grep jetty|grep -v grep|cut -d' ' -f1|xargs -r kill -9
+}
+
+cleanGradleCache () {
+  rm -rf "${GRADLE_CACHE}"
+  find "${D}" -name .gradle|xargs -r rm -rf
+}
+
+cleanGradleBuilds () {
+  find "${D}" -name build -o -name "*.log"|xargs -r rm -rf
+}
+
+killJetty
+
+# compile the moxie proxy
+(
+cd "${MOXIE_PROXY}"
+ant
+)
+
+# run the moxie proxy
+(
+cd "${MOXIE_PROXY}"
+ant run
+) >"${MOXIE_PROXY_OUTPUT}" 2>&1  &
+
+# clean the gradle cache
+cleanGradleCache
+
+RC=0
+for d in "${D}"/*; do
+  if [ -d "${d}" ]; then
+    (
+      cd "${d}"
+      gradle --gradle-user-home "${GRADLE_CACHE}" test
+    )
+    _RC=$?
+    if [ ${RC} -eq 0 ]; then
+	RC="${_RC}"
+    fi
+  fi
+done
+
+rm -f "${MOXIE_PROXY_OUTPUT}"
+killJetty
+cleanGradleCache
+cleanGradleBuilds
+
+if [ ${RC} -ne 0 ]; then
+  echo "${BN}: FAILURE, rc=${RC}"
+fi
+exit "${RC}"


### PR DESCRIPTION
With the current moxie master, the build doesn't succeed.
Do this to execute the gradle build:
1. Start the moxie proxy
   cd proxy
   rm -rf moxie
   ant run
2. Start the gradle build
   cd src/test/gradle/010-slf4j
   rm -rf ../gradle-user-home
   gradle --gradle-user-home $(pwd)/../gradle-user-home test

On linux, there is a script doing all of this:

   ./src/test/gradle/run-gradle-tests.sh

The build "gradle test" hangs here:

   ...
   :compileJava
   Download http://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.pom
   Download http://repo1.maven.org/maven2/org/slf4j/slf4j-parent/1.7.5/slf4j-parent-1.7.5.pom

> Building > :compileJava > Resolving dependencies ':compile'

The output of "cd proxy; ant run" is this:

   ...
   [mx:run] Download status: 200
   [mx:run] Content: 2689 bytes; text/xml
   [mx:run] Got request for http://repo1.maven.org/maven2/org/slf4j/slf4j-parent/1.7.5/slf4j-parent-1.7.5.pom
   [mx:run] Downloading to /home/uli/git/moxie/proxy/moxie/remote/repo1.maven.org_maven2/org/slf4j/slf4j-parent/1.7.5/slf4j-parent-1.7.5.pom
   [mx:run] Download status: 200
   [mx:run] Content: 11804 bytes; text/xml
   [mx:run] Found no URL to download in request:
   [mx:run] HEAD http://repo1.maven.org/maven2/org/slf4j/slf4j-parent/1.7.5/slf4j-parent-1.7.5.jar HTTP/1.1
   [mx:run] Accept-Encoding: gzip,deflate
   [mx:run] Host: repo1.maven.org
   [mx:run] Proxy-Connection: Keep-Alive
   [mx:run] User-Agent: Gradle/1.8-rc-1 (Linux;3.11.0-031100-generic;amd64) (Sun Microsystems Inc.;1.6.0_27;20.0-b12)
   [mx:run]
   [mx:run] indexing moxie/remote/repo1.maven.org_maven2/org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.pom
   [mx:run] indexing moxie/remote/repo1.maven.org_maven2/org/slf4j/slf4j-parent/1.7.5/slf4j-parent-1.7.5.pom

A patch for the issue will follow soon. I do have one available, I just
have to do some cleanup on it...
