### PR TITLE
Update URLs to use HTTPS

### DIFF
--- a/maxml/src/test/java/org/moxie/tests/TestMaxmlParser.java
+++ b/maxml/src/test/java/org/moxie/tests/TestMaxmlParser.java
@@ -33,7 +33,7 @@ public class TestMaxmlParser extends Assert {
 
 	String inlineMap = "{ id: myproxy, active: true, protocol: http, host:proxy.somewhere.com, port:8080, username: proxyuser, password: somepassword }";
 	
-	String inlineMap2 = "{ id: central, url: \"http://repo1.apache.org/maven\", url2: \"http://repo1.apache.org/maven\", affinity: [ 'org.moxie' ] }";
+	String inlineMap2 = "{ id: central, url: \"https://repo1.apache.org/maven\", url2: \"https://repo1.apache.org/maven\", affinity: [ 'org.moxie' ] }";
 	
 	String maplist = "developers :\n- {\n  id: james\n  name : James Moger\n  url : https://plus.google.com/u/0/116428776452027956920\n  roles : developer\n  }";
 	

--- a/proxy/proxy.moxie
+++ b/proxy/proxy.moxie
@@ -64,9 +64,9 @@ localRepositories:
 #
 # RESTART REQUIRED
 remoteRepositories:
-- { id: central, url: "http://repo1.maven.org/maven2" }
+- { id: central, url: "https://repo1.maven.org/maven2" }
 - {	id: restlet, url: "http://maven.restlet.org" }
-- {	id: sonatype-oss , url: "http://oss.sonatype.org/content/groups/public" }
+- { id: sonatype-oss , url: "https://oss.sonatype.org/content/groups/public" }
 
 # Enable the Restlet access log
 accessLog: false

--- a/proxy/proxy.moxie
+++ b/proxy/proxy.moxie
@@ -65,7 +65,7 @@ localRepositories:
 # RESTART REQUIRED
 remoteRepositories:
 - { id: central, url: "https://repo1.maven.org/maven2" }
-- {	id: restlet, url: "http://maven.restlet.org" }
+- { id: restlet, url: "https://maven.restlet.talend.com" }
 - { id: sonatype-oss , url: "https://oss.sonatype.org/content/groups/public" }
 
 # Enable the Restlet access log

--- a/proxy/src/main/config/proxy.moxie
+++ b/proxy/src/main/config/proxy.moxie
@@ -58,8 +58,8 @@ localRepositories:
 #
 # RESTART REQUIRED
 remoteRepositories:
-- {	id: 'restlet', url: "http://maven.restlet.org" }
 - { id: 'central', url: "https://repo1.maven.org/maven2" }
+- { id: 'restlet', url: "https://maven.restlet.talend.com" }
 - { id: 'sonatype-oss' , url: "https://oss.sonatype.org/content/groups/public" }
 
 # Enable the Restlet access log

--- a/proxy/src/main/config/proxy.moxie
+++ b/proxy/src/main/config/proxy.moxie
@@ -58,9 +58,9 @@ localRepositories:
 #
 # RESTART REQUIRED
 remoteRepositories:
-- { id: 'central', url: "http://repo1.maven.org/maven2" }
 - {	id: 'restlet', url: "http://maven.restlet.org" }
-- {	id: 'sonatype-oss' , url: "http://oss.sonatype.org/content/groups/public" }
+- { id: 'central', url: "https://repo1.maven.org/maven2" }
+- { id: 'sonatype-oss' , url: "https://oss.sonatype.org/content/groups/public" }
 
 # Enable the Restlet access log
 accessLog: false

--- a/proxy/src/main/java/org/moxie/proxy/ProxyConfig.java
+++ b/proxy/src/main/java/org/moxie/proxy/ProxyConfig.java
@@ -111,7 +111,7 @@ public class ProxyConfig {
 		
 		// default proxy of central
 		remoteRepositories = new ArrayList<RemoteRepository>();
-		remoteRepositories.add(new RemoteRepository("central", "http://repo1.maven.org/maven2", false));
+		remoteRepositories.add(new RemoteRepository("central", "https://repo1.maven.org/maven2", false));
 		
 		remoteRepositoryLookup = new HashMap<String, RemoteRepository>();
 		for (RemoteRepository repository : remoteRepositories) {

--- a/proxy/src/test/resources/proxy-test.moxie
+++ b/proxy/src/test/resources/proxy-test.moxie
@@ -14,8 +14,8 @@ localRepositories :
 
 # Remote Maven 2 Repositories which will be proxied on-demand
 remoteRepositories :
-- {	id: restlet, url: "http://maven.restlet.org" }
 - { id: central, url: "https://repo1.maven.org/maven2" }
+- {	id: restlet, url: "https://maven.restlet.talend.com" }
 
 # Enable the Restlet access log
 accessLog : false

--- a/proxy/src/test/resources/proxy-test.moxie
+++ b/proxy/src/test/resources/proxy-test.moxie
@@ -14,8 +14,8 @@ localRepositories :
 
 # Remote Maven 2 Repositories which will be proxied on-demand
 remoteRepositories :
-- { id: central, url: "http://repo1.maven.org/maven2" }
 - {	id: restlet, url: "http://maven.restlet.org" }
+- { id: central, url: "https://repo1.maven.org/maven2" }
 
 # Enable the Restlet access log
 accessLog : false
@@ -39,11 +39,11 @@ proxies :
 redirects :
 
 # Redirect all requests to central to the closest mirror
-- { from: "http://repo1.maven.org/maven2", to: "http://maven.sateh.com/maven2" }
+- { from: "https://repo1.maven.org/maven2", to: "https://maven.sateh.com/maven2" }
 
 # Sometimes, a POM will ask for a file from a mirror. In this case, direct
 # the requests to the closest mirror.
-- { from: "http://www.ibiblio.org/maven2", to: "http://maven.sateh.com/maven2" }
+- { from: "https://www.ibiblio.org/maven2", to: "https://maven.sateh.com/maven2" }
 
 # These two directories on the server always contain the same content (on
 # the server, one is a soft link to the other). We don't want to cache the

--- a/site/src/site/design.mkd
+++ b/site/src/site/design.mkd
@@ -51,7 +51,7 @@ A typical Moxie root directory structure may look something like the following:
   +--[releases]
   +--[restlet]
 [remote]
-  +--[maven.restlet.org]
+  +--[maven.restlet.talend.com]
   +--[repo1.maven.org_maven2]
     +--[commons-io]
       +--[commons-io]

--- a/site/src/site/moxiedescriptor.mkd
+++ b/site/src/site/moxiedescriptor.mkd
@@ -207,9 +207,9 @@ In the following example, the *Restlet* repository has an affinity for all artif
 
 ---YAML---
 registeredRepositories:
-- { id: 'central', url: 'http://repo1.maven.org/maven2' }
-- { id: 'mavencentral', url: 'http://repo1.maven.org/maven2' }
 - { id: 'codehaus', url: 'http://repository.codehaus.org' }
+- { id: 'central', url: 'https://repo1.maven.org/maven2' }
+- { id: 'mavencentral', url: 'https://repo1.maven.org/maven2' }
 - {
     id: 'sonatype-oss'
     url: 'https://oss.sonatype.org/content/groups/public'

--- a/site/src/site/moxiedescriptor.mkd
+++ b/site/src/site/moxiedescriptor.mkd
@@ -207,7 +207,6 @@ In the following example, the *Restlet* repository has an affinity for all artif
 
 ---YAML---
 registeredRepositories:
-- { id: 'codehaus', url: 'http://repository.codehaus.org' }
 - { id: 'central', url: 'https://repo1.maven.org/maven2' }
 - { id: 'mavencentral', url: 'https://repo1.maven.org/maven2' }
 - {

--- a/site/src/site/moxiedescriptor.mkd
+++ b/site/src/site/moxiedescriptor.mkd
@@ -218,7 +218,7 @@ registeredRepositories:
   }
 - { 
     id: 'restlet'
-    url: 'http://maven.restlet.org'
+    url: 'https://maven.restlet.talend.com'
     # Snapshot Purge Policy
     revisionRetentionCount: 1
     revisionPurgeAfterDays: 0

--- a/site/src/site/references.mkd
+++ b/site/src/site/references.mkd
@@ -6,7 +6,7 @@
 [Jetty]: http://eclipse.org/jetty "Jetty"
 [Lucene]: http://lucene.apache.org "Apache Lucene"
 [GenJar]: http://genjar.sourceforge.net "GenJar"
-[Restlet]: http://restlet.org "Restlet"
+[Restlet]: http://restlet.talend.com "Restlet"
 [Freemarker]: http://freemarker.sourceforge.net "Freemarker"
 [Moxie+Ant]: moxie+ant.html "Moxie+Ant distribution"
 [YAML]: http://yaml.org "YAML"

--- a/site/src/site/settings.mkd
+++ b/site/src/site/settings.mkd
@@ -55,9 +55,9 @@ The default *readTimeout* is 1800 seconds (30 mins).
 
 ---YAML---
 registeredRepositories:
-- { id: 'central', url: 'http://repo1.maven.org/maven2' }
-- { id: 'mavencentral', url: 'http://repo1.maven.org/maven2' }
 - { id: 'codehaus', url: 'http://repository.codehaus.org' }
+- { id: 'central', url: 'https://repo1.maven.org/maven2' }
+- { id: 'mavencentral', url: 'https://repo1.maven.org/maven2' }
 - {
     id: 'sonatype-oss'
     url: 'https://oss.sonatype.org/content/groups/public'
@@ -67,7 +67,7 @@ registeredRepositories:
   }
 - {
     id: 'restlet'
-    url: 'http://maven.restlet.org'
+    url: 'https://maven.restlet.org'
     # Snapshot Purge Policy
     revisionRetentionCount: 1
     revisionPurgeAfterDays: 0

--- a/site/src/site/settings.mkd
+++ b/site/src/site/settings.mkd
@@ -55,7 +55,6 @@ The default *readTimeout* is 1800 seconds (30 mins).
 
 ---YAML---
 registeredRepositories:
-- { id: 'codehaus', url: 'http://repository.codehaus.org' }
 - { id: 'central', url: 'https://repo1.maven.org/maven2' }
 - { id: 'mavencentral', url: 'https://repo1.maven.org/maven2' }
 - {

--- a/site/src/site/settings.mkd
+++ b/site/src/site/settings.mkd
@@ -66,7 +66,7 @@ registeredRepositories:
   }
 - {
     id: 'restlet'
-    url: 'https://maven.restlet.org'
+    url: 'https://maven.restlet.talend.com'
     # Snapshot Purge Policy
     revisionRetentionCount: 1
     revisionPurgeAfterDays: 0

--- a/toolkit/src/all/resources/maven/index.html
+++ b/toolkit/src/all/resources/maven/index.html
@@ -9,7 +9,7 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.5/angular.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.5/angular-resource.min.js"></script>
-    <script src="http://angular-ui.github.com/bootstrap/ui-bootstrap-tpls-0.2.0.js"></script>
+    <script src="https://angular-ui.github.io/bootstrap/ui-bootstrap-tpls-0.2.0.js"></script>
     <!--<script src="https://google-code-prettify.googlecode.com/svn/loader/prettify.js"></script>-->
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
     <style type="text/css">

--- a/toolkit/src/core/java/org/moxie/ToolkitConfig.java
+++ b/toolkit/src/core/java/org/moxie/ToolkitConfig.java
@@ -103,7 +103,7 @@ public class ToolkitConfig implements Serializable {
 		targetDirectory = new File("build/target");
 		linkedModules = new ArrayList<Module>();
 		repositories = Arrays.asList("central");
-		registeredRepositories = Arrays.asList(new RemoteRepository("central", "http://repo1.maven.org/maven2", false));
+		registeredRepositories = Arrays.asList(new RemoteRepository("central", "https://repo1.maven.org/maven2/", false));
 		pom = new Pom();
 		dependencyDirectory = null;
 		dependencyNamePattern = Toolkit.DEPENDENCY_FILENAME_PATTERN;

--- a/toolkit/src/core/resources/settings.moxie
+++ b/toolkit/src/core/resources/settings.moxie
@@ -16,7 +16,6 @@ proxies:
 # a complete url.  A repository definition can override the default snapshot
 # revision purge policy.
 registeredRepositories:
-- { id: 'codehaus', url: 'http://repository.codehaus.org' }
 - { id: 'central', url: 'https://repo1.maven.org/maven2' }
 - { id: 'mavencentral', url: 'https://repo1.maven.org/maven2' }
 - {

--- a/toolkit/src/core/resources/settings.moxie
+++ b/toolkit/src/core/resources/settings.moxie
@@ -16,9 +16,9 @@ proxies:
 # a complete url.  A repository definition can override the default snapshot
 # revision purge policy.
 registeredRepositories:
-- { id: 'central', url: 'http://repo1.maven.org/maven2' }
-- { id: 'mavencentral', url: 'http://repo1.maven.org/maven2' }
 - { id: 'codehaus', url: 'http://repository.codehaus.org' }
+- { id: 'central', url: 'https://repo1.maven.org/maven2' }
+- { id: 'mavencentral', url: 'https://repo1.maven.org/maven2' }
 - {
     id: 'sonatype-oss'
     url: 'https://oss.sonatype.org/content/groups/public'
@@ -27,7 +27,7 @@ registeredRepositories:
   }
 - {
     id: 'restlet'
-    url: 'http://maven.restlet.org'
+    url: 'https://maven.restlet.org'
     revisionRetentionCount: 1
     revisionPurgeAfterDays: 0
     # define a groupid affinity for all org.restlet artifacts

--- a/toolkit/src/core/resources/settings.moxie
+++ b/toolkit/src/core/resources/settings.moxie
@@ -26,7 +26,7 @@ registeredRepositories:
   }
 - {
     id: 'restlet'
-    url: 'https://maven.restlet.org'
+    url: 'https://maven.restlet.talend.com'
     revisionRetentionCount: 1
     revisionPurgeAfterDays: 0
     # define a groupid affinity for all org.restlet artifacts


### PR DESCRIPTION
Since January 2020, Maven Central has stopped accepting the http transport.
This pull request updates URLs to the built-in default registeredRepositories
to use https.

Also, it updates the link to Angular-UI to use https, so that the constructed
Maven repository will work via https.

Next, it updates the URL for Restlet, which changed to talent.com and
now also uses https.

Remove the Codehaus maven repository from registeredRepositories.

This is a redo of PR #10, fixing places that were missed and adding the change
or the Restlet URL.